### PR TITLE
Added information how to deploy on Docker with ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Docker Hub: [thelovinator/discord-twitter-webhooks](https://hub.docker.com/r/the
   - You can automate this with [Watchtower](https://github.com/containrrr/watchtower)
       or [Diun](https://github.com/crazy-max/diun)
 - To use this project on ARM64 platform such as Raspberry Pi 4, you need to modify the docker-compose.yml file with the following.  
-  - Change this line ``image: thelovinator/discord-twitter-webhooks`` to      this:  
+  - Change this line from ``image: thelovinator/discord-twitter-webhooks`` to      this:  
   ```
    build:
       context: .

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Docker Hub: [thelovinator/discord-twitter-webhooks](https://hub.docker.com/r/the
 - You can update the container with `docker-compose pull`
   - You can automate this with [Watchtower](https://github.com/containrrr/watchtower)
       or [Diun](https://github.com/crazy-max/diun)
+- To use this project on ARM64 platform such as Raspberry Pi 4, you need to modify the docker-compose.yml file with the following.  
+  - Change this line ``image: thelovinator/discord-twitter-webhooks`` to      this:  
+  ```
+   build:
+      context: .
+      platforms:
+        - "linux/arm64"
+  ```
+  - And run normally
 
 ### Install directly on your computer
 


### PR DESCRIPTION
Addition to the Docker chapter how to change the docker-compose file for ARM64 platform. User needs to build the image themself.
If you are planning to build directly for ARM64, this can be ignored.