### PR TITLE
Added random color for webhook embed notifications

### DIFF
--- a/discord_twitter_webhooks/get_settings.py
+++ b/discord_twitter_webhooks/get_settings.py
@@ -464,3 +464,10 @@ def get_webhook_show_timestamp() -> bool:
         bool: The value of the setting. Defaults to False.
     """
     return get_setting_value(setting_name="SHOW_TIMESTAMP", default_value=False)
+
+def get_embed_colors() -> bool:
+    """If we should use a random color in the embed.
+    Returns:
+        bool: The value of the setting. Defaults to False.
+    """
+    return get_setting_value(setting_name="RANDOM_EMBED_COLORS", default_value=False)

--- a/discord_twitter_webhooks/send_webhook.py
+++ b/discord_twitter_webhooks/send_webhook.py
@@ -3,6 +3,7 @@ import json
 import requests
 from discord_webhook import DiscordEmbed, DiscordWebhook
 from loguru import logger
+from random import randint
 
 from discord_twitter_webhooks import settings
 
@@ -90,6 +91,11 @@ def send_embed_webhook(
         # TODO: Truncate author if it's too long.
         # TODO: Add support for local images.
         embed.set_author(f"{display_name} (@{username})", url=tweet_url, icon_url=avatar_url)
+
+    # Add random color to the embed webhook
+    if settings.webhook_random_embed_colors:
+        embed.set_color(hex(randint(0, 16777215))[2:])
+
 
     # Add embed to webhook.
     # TODO: Check if embed is working before adding it to the webhook.

--- a/discord_twitter_webhooks/settings.py
+++ b/discord_twitter_webhooks/settings.py
@@ -74,6 +74,7 @@ webhook_thumbnail: str = get_settings.get_webhook_thumbnail()
 webhook_footer_text: str = get_settings.get_webhook_footer_text()
 webhook_footer_icon: str = get_settings.get_webhook_footer_icon()
 webhook_show_timestamp: bool = get_settings.get_show_timestamp()
+webhook_random_embed_colors: bool = get_settings.get_embed_colors()
 use_title: bool = get_settings.get_use_title()
 use_author: bool = get_settings.get_use_author()
 


### PR DESCRIPTION
Allows users to use random embed colors to help visually identify different tweets more easily. 

By default this option is disabled in the configuration file.