### PR TITLE
Update username regex in replace.py

### DIFF
--- a/discord_twitter_webhooks/replace.py
+++ b/discord_twitter_webhooks/replace.py
@@ -17,8 +17,8 @@ def username_with_link(text: str) -> str:
         Text with the username replaced with a link
     """
     regex: str = re.sub(
-        r" (@(\w*))",
-        r" [\g<1>](https://twitter.com/\g<2>)",
+        r"(@(\w{1,15}\b))",
+        r"[\g<1>](https://twitter.com/\g<2>)",
         text,
     )
 


### PR DESCRIPTION
Updated regex for @ usernames. 

This change will limit usernames to 15 characters which is the twitter username character limit and fixes the issue of not detecting usernames in tweets if the first character of a tweet isn't a whitespace.

Fixes issues #91